### PR TITLE
Fixed macOS bug of minimization on startup

### DIFF
--- a/src/edu/rice/cs/drjava/ui/MainFrame.java
+++ b/src/edu/rice/cs/drjava/ui/MainFrame.java
@@ -7548,6 +7548,7 @@ public class MainFrame extends SwingFrame implements ClipboardOwner, DropTargetL
     EventQueue.invokeLater(new Runnable() { 
       public void run() { 
         setVisible(true);
+        setExtendedState(getExtendedState() | JFrame.MAXIMIZED_BOTH);
         _compilerErrorPanel.setVisible(true);
         showTab(_compilerErrorPanel, true); 
         /* The following two step sequence was laboriously developed by trial and error; without it the _tabbedPane


### PR DESCRIPTION
Fixes bug on macOS of the application window minimizing on startup. This edit should force MainFrame to maximize to the screen limits after the JFrame is created.